### PR TITLE
Fix program crash from invalid AWS credentials.

### DIFF
--- a/S3_File_Uploader/Database.py
+++ b/S3_File_Uploader/Database.py
@@ -351,6 +351,14 @@ class Database:
         logger.debug(f'Commiting database.')
 
     @_only_context
+    def make_aws_config_inactive(self) -> None:
+        self.cursor.execute("Update aws_config SET is_active = 0 WHERE is_active = 1;")
+        logger.debug(f'Setting saved AWS config to not active.')
+
+        self.connection.commit()
+        logger.debug(f'Commiting database.')
+
+    @_only_context
     def are_settings_saved(self):
         logger.debug(f'Checking if settings are saved on the database.')
 


### PR DESCRIPTION
Database.py -
* Create a database function to make aws config inactive.

AWS.py -
* Catch botocore exception with InvalidAccessKeyId in `get_s3_buckets()`
* If the botocore exception is raised, then the DB function to make aws config inactive is ran.
* A message is displayed to the user in the command prompt/terminal to close and reopen the application
Resolves #29